### PR TITLE
bug fixed - pass the shellray.com limitation

### DIFF
--- a/BackdoorMan
+++ b/BackdoorMan
@@ -428,7 +428,14 @@ class Servicer:
 		# | 5.free services of nimbusec.            |
 		# +=========================================+
 		try:
-			r = requests.post('https://shellray.com/upload', files={'file':self.file})
+			while 1:
+				try:
+					r = requests.post('https://shellray.com/upload', files={'file':self.file})
+					if r.status_code is 200:
+						break
+				except:
+					pass
+				sleep(0.5)
 			data = r.json()
 			if not data['infected']:
 				return False


### PR DESCRIPTION
Hey,

Nice tool you made here, BTW while I was using it, I've got this error.

```
[*] Scanning: /home/ubuntu/samples/1/
[*] Started: 2018-01-05 02:52:59.869676
[M] Suspicious Function: 24.php
 |  Function Name: base64_decode
 |  Line Number: 1
 |  Full Path: /home/ubuntu/samples/1/24.php
 |  Owner: 1000:1000
 |  Permission: 644
 |  Last Accessed: Fri Jan  5 02:03:17 2018
 |  Last Modified: Fri Jan  5 00:45:16 2018
 |  File Size: 6.8KiB
[H] Suspicious Function: 24.php
 |  Function Name: eval
 |  Line Number: 1
 |  Full Path: /home/ubuntu/samples/1/24.php
 |  Owner: 1000:1000
 |  Permission: 644
 |  Last Accessed: Fri Jan  5 02:03:17 2018
 |  Last Modified: Fri Jan  5 00:45:16 2018
 |  File Size: 6.8KiB
[H] Malware Detected: 24.php
 |  Service Provider: shellray
 |  Threat Name: php.obfuscated
 |  SHA1: 70dec83d44e354b68901a47e0c949849372afd5e
 |  MD5: 4670c8e22bffb08804de78bf9d52f4d0
 |  Full Path: /home/ubuntu/samples/1/24.php
 |  Owner: 1000:1000
 |  Permission: 644
 |  Last Accessed: Fri Jan  5 02:03:17 2018
 |  Last Modified: Fri Jan  5 00:45:16 2018
 |  File Size: 6.8KiB
[M] Suspicious Function: 47.php
 |  Function Name: base64_decode
 |  Line Number: 1
 |  Full Path: /home/ubuntu/samples/1/47.php
 |  Owner: 1000:1000
 |  Permission: 644
 |  Last Accessed: Fri Jan  5 02:03:17 2018
 |  Last Modified: Fri Jan  5 00:45:16 2018
 |  File Size: 2.6KiB
[H] Suspicious Function: 47.php
 |  Function Name: eval
 |  Line Number: 1
 |  Full Path: /home/ubuntu/samples/1/47.php
 |  Owner: 1000:1000
 |  Permission: 644
 |  Last Accessed: Fri Jan  5 02:03:17 2018
 |  Last Modified: Fri Jan  5 00:45:16 2018
 |  File Size: 2.6KiB
Traceback (most recent call last):
  File "./BackdoorMan", line 604, in <module>
    Initialize(dest)
  File "./BackdoorMan", line 75, in __init__
    self.list()
  File "./BackdoorMan", line 98, in list
    self.PHPScan(file)
  File "./BackdoorMan", line 337, in PHPScan
    response = servicer.shellray()
  File "./BackdoorMan", line 433, in shellray
    data = r.json()
  File "/home/ubuntu/.local/lib/python2.7/site-packages/requests/models.py", line 892, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

so I check up the [line 433](https://github.com/cys3c/BackdoorMan/blob/master/BackdoorMan#L433)  to see what's going on. I release that shellray.com has request limitation in time.

normal response: (with code 200)
```
{
        "infected": true,
        "threatname": "php.obfuscated",
        "filename": "24.php",
        "md5": "4670c8e22bffb08804de78bf9d52f4d0",
        "sha1": "70dec83d44e354b68901a47e0c949849372afd5e",
        "size": 6979
}
``` 

error response: (with code 429)
```
You have reached maximum request limit.
```
so a while with a 0.5 sleep helped to fix this issue. and I hope it's cool that I share the issue and the fixation.

keep it up.
Regards.

