### PR TITLE
bug fix - Error on open file

### DIFF
--- a/BackdoorMan
+++ b/BackdoorMan
@@ -44,25 +44,25 @@ class Initialize:
 		self.destination = destination
 		self.totalThreats = 0
 		self.isNR = self.isNetworkReachable()
-		self.shells = open('databases/shells.txt', 'rb').read().split('\n')
+		self.shells = open('databases/shells.txt', 'r').read().split('\n')
 
 		self.lowFuncts = '|'.join(
-			open('databases/functions/low.txt', 'rb').read().strip().split('\n')
+			open('databases/functions/low.txt', 'r').read().strip().split('\n')
 		)
 		self.mediumFuncts = '|'.join(
-			open('databases/functions/medium.txt', 'rb').read().strip().split('\n')
+			open('databases/functions/medium.txt', 'r').read().strip().split('\n')
 		)
 		self.highFuncts = '|'.join(
-			open('databases/functions/high.txt', 'rb').read().strip().split('\n')
+			open('databases/functions/high.txt', 'r').read().strip().split('\n')
 		)
 		self.lowActivs = '|'.join(
-			open('databases/activities/low.txt', 'rb').read().strip().split('\n')
+			open('databases/activities/low.txt', 'r').read().strip().split('\n')
 		)
 		self.mediumActivs = '|'.join(
-			open('databases/activities/medium.txt', 'rb').read().strip().split('\n')
+			open('databases/activities/medium.txt', 'r').read().strip().split('\n')
 		)
 		self.highActivs = '|'.join(
-			open('databases/activities/high.txt', 'rb').read().strip().split('\n')
+			open('databases/activities/high.txt', 'r').read().strip().split('\n')
 		)
 
 		isFile = os.path.isfile(destination)
@@ -100,7 +100,7 @@ class Initialize:
 	def PHPScan(self, file):
 		filename = os.path.basename(file)
 		fileThreats = {}
-		f = self.prepare(open(file, 'rb').read())
+		f = self.prepare(open(file, 'r').read())
 		string = ''.join(f.split('\n'))
 		# +====================+
 		# | Step 1: Web Shells |


### PR DESCRIPTION
I tried to run this script, but i got a error.
 

`Traceback (most recent call last):
  File "/home/kali/Downloads/vulns/BackdoorMan/./BackdoorMan", line 603, in <module>
    Initialize(dest)
  File "/home/kali/Downloads/vulns/BackdoorMan/./BackdoorMan", line 50, in __init__
    open('databases/functions/low.txt', 'rb').read().strip().split('\n')
TypeError: a bytes-like object is required, not 'str'`

I got the same error in this two machines:
* Linux kali 6.0.0-kali5-amd64 SMP PREEMPT_DYNAMIC Debian 6.0.10-2kali1 (2022-12-06) x86_64 GNU/Linux
* Linux calistu-debian 5.10.0-13-amd64 SMP Debian 5.10.106-1 (2022-03-17) x86_64 GNU/Linux

So, i fix this error removing the binary parameter on open() function.
> Before: open(file, 'rb')
> After: open(file, 'r')

Since the files are in text format, I believe there is no need to use the binary attribute.